### PR TITLE
Limit cache/informers to given namespace

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,3 +53,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--namespace=$(POD_NAMESPACE)"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --namespace=$(POD_NAMESPACE)
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,19 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-role
+  namespace: system
+rules:
+- apiGroups:
   - ""
   resources:
   - secrets
@@ -31,12 +44,6 @@ rules:
   - ""
   resources:
   - serviceaccounts/token
-  verbs:
-  - create
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
   verbs:
   - create
 - apiGroups:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -17,3 +17,23 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: emergency-credentials-controller
+    app.kubernetes.io/part-of: emergency-credentials-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-rolebinding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager

--- a/controllers/emergencyaccount_controller.go
+++ b/controllers/emergencyaccount_controller.go
@@ -35,12 +35,12 @@ type EmergencyAccountReconciler struct {
 	Clock Clock
 }
 
-//+kubebuilder:rbac:groups=cluster.appuio.io,resources=emergencyaccounts,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cluster.appuio.io,resources=emergencyaccounts/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=cluster.appuio.io,resources=emergencyaccounts/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.appuio.io,resources=emergencyaccounts,verbs=get;list;watch;create;update;patch;delete,namespace="system"
+//+kubebuilder:rbac:groups=cluster.appuio.io,resources=emergencyaccounts/status,verbs=get;update;patch,namespace="system"
+//+kubebuilder:rbac:groups=cluster.appuio.io,resources=emergencyaccounts/finalizers,verbs=update,namespace="system"
 
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete,namespace="system"
+//+kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create,namespace="system"
 
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 

--- a/controllers/stores/secret_store.go
+++ b/controllers/stores/secret_store.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch,namespace="system"
 
 type SecretStore struct {
 	SecretStoreSpec emcv1beta1.SecretStoreSpec


### PR DESCRIPTION
This should improve security; controller will only be able to check secrets in its own namespace. It also has the potential to lower resource usage drastically on bigger clusters with many objects.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
